### PR TITLE
Downgrade minimum deployment targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "BetterCodable",
     platforms: [
-        .iOS(.v13),
-        .macOS(.v10_15),
-        .tvOS(.v13),
-        .watchOS(.v6)
+        .iOS(.v10),
+        .macOS(.v10_12),
+        .tvOS(.v10),
+        .watchOS(.v3)
     ],
     products: [
         .library(


### PR DESCRIPTION
The library does not make any use of code which is specific to iOS 13 and friends. This PR downgrades the min deployment target to iOS 10, macOS 10.12, tvOS 10, and watchOS 3, which is when `ISO8601DateFormatter` was introduced and is thus the lower limit of the deployment target.