### PR TITLE
feat: Add DefaultInit feature

### DIFF
--- a/Sources/BetterCodable/DefaultInit.swift
+++ b/Sources/BetterCodable/DefaultInit.swift
@@ -1,0 +1,12 @@
+public protocol Initable: Codable {
+    init()
+}
+
+public enum DefaultInitableStrategy<T: Initable>: DefaultCodableStrategy {
+    public static var defaultValue: T { T() }
+}
+
+/// Decodes values with `T()` value of `Initable` protocol conformed type instead of nil if applicable
+///
+/// `@DefaultInit` decodes values and returns an `T()` value instead of nil if the Decoder is unable to decode the container.
+public typealias DefaultInit<T> = DefaultCodable<DefaultInitableStrategy<T>> where T: Initable

--- a/Tests/BetterCodableTests/DefaultInitTests.swift
+++ b/Tests/BetterCodableTests/DefaultInitTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import BetterCodable
+
+class DefaultInitTests: XCTestCase {
+    struct Fixture: Codable {
+        @DefaultInit var text: String
+        @DefaultInit var integer: Int
+        @DefaultInit var array: [Int]
+        @DefaultInit var dict: [String: Int]
+    }
+    
+    func testDecodingFailableToDefaultInitValue() throws {
+        let json = #"{ "text": null, "integer": null, "array": null, "dict": null }"#.data(using: .utf8)!
+        let fixture = try! JSONDecoder().decode(Fixture.self, from: json)
+        
+        XCTAssertEqual(fixture.text, "")
+        XCTAssertEqual(fixture.integer, 0)
+        XCTAssertEqual(fixture.array, [])
+        XCTAssertEqual(fixture.dict, [:])
+    }
+    
+}
+
+extension String: Initable {}
+extension Int: Initable {}
+extension Array: Initable where Element: Codable {}
+extension Dictionary: Initable where Key: Codable, Value: Codable {}
+


### PR DESCRIPTION
This PR add `@DefaultInit` feature that using `DefaultCodable`.

Should we conforming many swift basic types (e.g. `String`) to `Initable` in BetterCodable package? What do you think?