### PR TITLE
Add support to DefaultCodable to default when key is not available

### DIFF
--- a/Sources/BetterCodable/DefaultCodable.swift
+++ b/Sources/BetterCodable/DefaultCodable.swift
@@ -30,3 +30,18 @@ public struct DefaultCodable<Default: DefaultCodableStrategy>: Codable {
 
 extension DefaultCodable: Equatable where Default.RawValue: Equatable { }
 extension DefaultCodable: Hashable where Default.RawValue: Hashable { }
+
+// MARK: - KeyedDecodingContainer
+public extension KeyedDecodingContainer {
+
+    /// Default implementation of decoding a DefaultCodable
+    ///
+    /// Decodes successfully if key is available if not fallsback to the default value provided.
+    func decode<P>(_: DefaultCodable<P>.Type, forKey key: Key) throws -> DefaultCodable<P> {
+        if let value = try decodeIfPresent(DefaultCodable<P>.self, forKey: key) {
+            return value
+        } else {
+            return DefaultCodable(wrappedValue: P.defaultValue)
+        }
+    }
+}

--- a/Tests/BetterCodableTests/DefaulEmptyDictionaryTests.swift
+++ b/Tests/BetterCodableTests/DefaulEmptyDictionaryTests.swift
@@ -11,6 +11,12 @@ class DefaultEmptyDictionaryTests: XCTestCase {
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.stringToInt, [:])
     }
+
+    func testDecodingKeyNotPresentDefaultsToEmptyDictionary() throws {
+        let jsonData = #"{}"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.stringToInt, [:])
+    }
     
     func testEncodingDecodedFailableDictionaryDefaultsToEmptyDictionary() throws {
         let jsonData = #"{ "stringToInt": null }"#.data(using: .utf8)!

--- a/Tests/BetterCodableTests/DefaultEmptyArrayTests.swift
+++ b/Tests/BetterCodableTests/DefaultEmptyArrayTests.swift
@@ -18,6 +18,13 @@ class DefaultEmptyArrayTests: XCTestCase {
         XCTAssertEqual(fixture.values, [])
         XCTAssertEqual(fixture.nonPrimitiveValues, [])
     }
+
+    func testDecodingKeyNotPresentDefaultsToEmptyArray() throws {
+        let jsonData = #"{}"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.values, [])
+        XCTAssertEqual(fixture.nonPrimitiveValues, [])
+    }
     
     func testEncodingDecodedFailableArrayDefaultsToEmptyArray() throws {
         let jsonData = #"{ "values": null, "nonPrimitiveValues": null }"#.data(using: .utf8)!

--- a/Tests/BetterCodableTests/DefaultFalseTests.swift
+++ b/Tests/BetterCodableTests/DefaultFalseTests.swift
@@ -6,7 +6,7 @@ class DefaultFalseTests: XCTestCase {
         @DefaultFalse var truthy: Bool
     }
     
-    func testDecodingFailableArrayDefaultsToEmptyArray() throws {
+    func testDecodingFailableArrayDefaultsToFalse() throws {
         let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.truthy, false)
@@ -18,7 +18,7 @@ class DefaultFalseTests: XCTestCase {
         XCTAssertEqual(fixture.truthy, false)
     }
     
-    func testEncodingDecodedFailableArrayDefaultsToEmptyArray() throws {
+    func testEncodingDecodedFailableArrayDefaultsToFalse() throws {
         let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
         var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         
@@ -29,7 +29,7 @@ class DefaultFalseTests: XCTestCase {
         XCTAssertEqual(fixture.truthy, true)
     }
     
-    func testEncodingDecodedFulfillableArrayRetainsContents() throws {
+    func testEncodingDecodedFulfillableBoolRetainsValue() throws {
         let jsonData = #"{ "truthy": true }"#.data(using: .utf8)!
         let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         let fixtureData = try JSONEncoder().encode(_fixture)

--- a/Tests/BetterCodableTests/DefaultFalseTests.swift
+++ b/Tests/BetterCodableTests/DefaultFalseTests.swift
@@ -11,6 +11,12 @@ class DefaultFalseTests: XCTestCase {
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.truthy, false)
     }
+
+    func testDecodingKeyNotPresentDefaultsToFalse() throws {
+        let jsonData = #"{}"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.truthy, false)
+    }
     
     func testEncodingDecodedFailableArrayDefaultsToEmptyArray() throws {
         let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!


### PR DESCRIPTION
DefaultCodable currently only defaults when the key is available and the value is null. However, when the key is not available it throws a decoding error. To solve this I borrowed from [this repository](https://github.com/gonzalezreal/DefaultCodable?utm_campaign=iOS%2BDev%2BWeekly&utm_medium=email&utm_source=iOS%2BDev%2BWeekly%2BIssue%2B443) the idea to give `DefaultCodable` a default `decode` implementation to handle this scenario. 

Moreover, this PR fixes some test names as well