### PR TITLE
Add Cocoapods support

### DIFF
--- a/BetterCodable.podspec
+++ b/BetterCodable.podspec
@@ -1,0 +1,19 @@
+Pod::Spec.new do |s|
+	s.name         = 'BetterCodable'
+	s.version      = '0.1.0'
+	s.swift_versions = ['5.1']
+	s.summary      = 'Better Codable through Property Wrappers'
+	s.homepage     = 'https://github.com/marksands/BetterCodable'
+	s.license      = { :type => 'MIT', :file => 'LICENSE' }
+	s.author       = { 'Mark Sands' => 'http://marksands.github.io/' }
+	s.social_media_url   = 'https://twitter.com/marksands'
+
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '10.0'
+  s.watchos.deployment_target = '3.0'
+
+  s.source       = { :git => 'https://github.com/marksands/BetterCodable.git', :tag => s.version.to_s }
+	s.source_files  = 'Sources/**/*.swift'
+	s.frameworks  = 'Foundation'
+end

--- a/README.md
+++ b/README.md
@@ -266,8 +266,14 @@ let result = try JSONDecoder().decode(Response.self, from: json)
 
 ## Installation
 
-Swift Package Manager
+### CocoaPods
 
-### Attribution
+```ruby
+pod 'BetterCodable', '~> 0.1.0'
+```
+
+### Swift Package Manager
+
+## Attribution
 
 This project is licensed under MIT. If you find these useful, please tell your boss where you found them.


### PR DESCRIPTION
Fixes #4 

@marksands Still need to push the spec through `pod trunk push BetterCodable.podspec`, but I will leave that to you.