### PR TITLE
Allow LosslessValue property usage outside Codable

### DIFF
--- a/Sources/BetterCodable/LosslessValue.swift
+++ b/Sources/BetterCodable/LosslessValue.swift
@@ -12,6 +12,11 @@ public struct LosslessValue<T: LosslessStringCodable>: Codable {
     private let type: LosslessStringCodable.Type
     
     public var wrappedValue: T
+
+    public init(wrappedValue: T) {
+        self.wrappedValue = wrappedValue
+        self.type = T.self
+    }
     
     public init(from decoder: Decoder) throws {
         do {


### PR DESCRIPTION
This PR fixes #25 the same was as it is solved in `DateValue`.