### PR TITLE
Test cases for LosslessValue Bool Int value

### DIFF
--- a/Sources/BetterCodable/DefaultCodable.swift
+++ b/Sources/BetterCodable/DefaultCodable.swift
@@ -66,8 +66,6 @@ public extension KeyedDecodingContainer {
                 case .typeMismatch = decodingError else {
                     return DefaultCodable(wrappedValue: P.defaultValue)
             }
-            // Not sure if it is worth adding the Double, Float, and other cases.
-            // In reality backend should never return double, or floating point values for bools but hey we are here for a reason 🤷🏻‍♂️
             if let intValue = try? decodeIfPresent(Int.self, forKey: key),
                 let bool = Bool(exactly: NSNumber(value: intValue)) {
                 return DefaultCodable(wrappedValue: bool)

--- a/Sources/BetterCodable/DefaultCodable.swift
+++ b/Sources/BetterCodable/DefaultCodable.swift
@@ -36,6 +36,8 @@ extension DefaultCodable: Equatable where Default.RawValue: Equatable { }
 extension DefaultCodable: Hashable where Default.RawValue: Hashable { }
 
 // MARK: - KeyedDecodingContainer
+public protocol BoolCodableStrategy: DefaultCodableStrategy where RawValue == Bool {}
+
 public extension KeyedDecodingContainer {
 
     /// Default implementation of decoding a DefaultCodable
@@ -56,7 +58,7 @@ public extension KeyedDecodingContainer {
         } catch let error {
             guard let decodingError = error as? DecodingError,
                 case .typeMismatch = decodingError else {
-                    return DefaultCodable(wrappedValue: DefaultFalseStrategy.defaultValue)
+                    return DefaultCodable(wrappedValue: P.defaultValue)
             }
             if let intValue = try? decodeIfPresent(Int.self, forKey: key),
                 let bool = Bool(exactly: NSNumber(value: intValue)) {
@@ -65,7 +67,7 @@ public extension KeyedDecodingContainer {
                 let bool = Bool(stringValue) {
                 return DefaultCodable(wrappedValue: bool)
             } else {
-                return DefaultCodable(wrappedValue: DefaultFalseStrategy.defaultValue)
+                return DefaultCodable(wrappedValue: P.defaultValue)
             }
         }
     }

--- a/Sources/BetterCodable/DefaultCodable.swift
+++ b/Sources/BetterCodable/DefaultCodable.swift
@@ -60,6 +60,8 @@ public extension KeyedDecodingContainer {
                 case .typeMismatch = decodingError else {
                     return DefaultCodable(wrappedValue: P.defaultValue)
             }
+            // Not sure if it is worth adding the Double, Float, and other cases.
+            // In reality backend should never return double, or floating point values for bools but hey we are here for a reason 🤷🏻‍♂️
             if let intValue = try? decodeIfPresent(Int.self, forKey: key),
                 let bool = Bool(exactly: NSNumber(value: intValue)) {
                 return DefaultCodable(wrappedValue: bool)

--- a/Sources/BetterCodable/DefaultCodable.swift
+++ b/Sources/BetterCodable/DefaultCodable.swift
@@ -51,6 +51,12 @@ public extension KeyedDecodingContainer {
         }
     }
 
+    /// Default implementation of decoding a `DefaultCodable` where its strategy is a `BoolCodableStrategy`.
+    ///
+    /// Tries to initially Decode a `Bool` if available, otherwise tries to decode it as an `Int` or `String`
+    /// when there is a `typeMismatch` decoding error. This preserves the actual value of the `Bool` in which
+    /// the data provider might be sending the value as different types. If everything fails defaults to
+    /// the `defaultValue` provided by the strategy.
     func decode<P: BoolCodableStrategy>(_: DefaultCodable<P>.Type, forKey key: Key) throws -> DefaultCodable<P> {
         do {
             let value = try decode(Bool.self, forKey: key)

--- a/Sources/BetterCodable/DefaultFalse.swift
+++ b/Sources/BetterCodable/DefaultFalse.swift
@@ -1,5 +1,3 @@
-public protocol BoolCodableStrategy: DefaultCodableStrategy where RawValue == Bool {}
-
 public struct DefaultFalseStrategy: BoolCodableStrategy {
     public static var defaultValue: Bool { return false }
 }

--- a/Sources/BetterCodable/DefaultFalse.swift
+++ b/Sources/BetterCodable/DefaultFalse.swift
@@ -1,4 +1,6 @@
-public struct DefaultFalseStrategy: DefaultCodableStrategy {
+public protocol BoolCodableStrategy: DefaultCodableStrategy where RawValue == Bool {}
+
+public struct DefaultFalseStrategy: BoolCodableStrategy {
     public static var defaultValue: Bool { return false }
 }
 

--- a/Sources/BetterCodable/DefaultTrue.swift
+++ b/Sources/BetterCodable/DefaultTrue.swift
@@ -1,0 +1,8 @@
+public struct DefaultTrueStrategy: BoolCodableStrategy {
+    public static var defaultValue: Bool { return true }
+}
+
+/// Decodes Bools defaulting to `true` if applicable
+///
+/// `@DefaultFalse` decodes Bools and defaults the value to true if the Decoder is unable to decode the value.
+public typealias DefaultTrue = DefaultCodable<DefaultTrueStrategy>

--- a/Sources/BetterCodable/DefaultTrue.swift
+++ b/Sources/BetterCodable/DefaultTrue.swift
@@ -4,5 +4,5 @@ public struct DefaultTrueStrategy: BoolCodableStrategy {
 
 /// Decodes Bools defaulting to `true` if applicable
 ///
-/// `@DefaultFalse` decodes Bools and defaults the value to true if the Decoder is unable to decode the value.
+/// `@DefaultTrue` decodes Bools and defaults the value to true if the Decoder is unable to decode the value.
 public typealias DefaultTrue = DefaultCodable<DefaultTrueStrategy>

--- a/Sources/BetterCodable/LosslessValue.swift
+++ b/Sources/BetterCodable/LosslessValue.swift
@@ -44,7 +44,7 @@ public struct LosslessValue<T: LosslessStringCodable>: Codable {
                 decode(Double.self),
                 decode(Float.self),
                 ]
-            
+
             guard
                 let rawValue = types.lazy.compactMap({ $0(decoder) }).first,
                 let value = T.init("\(rawValue)")

--- a/Tests/BetterCodableTests/DefaultFalseTests.swift
+++ b/Tests/BetterCodableTests/DefaultFalseTests.swift
@@ -38,7 +38,7 @@ class DefaultFalseTests: XCTestCase {
         XCTAssertEqual(fixture.truthy, true)
     }
 
-    func testDecodingMisalignedBoolIntValueFromJSONTraversesCorrectType() throws {
+    func testDecodingMisalignedBoolIntValueDecodesCorrectBoolValue() throws {
         let jsonData = #"{ "truthy": 1 }"#.data(using: .utf8)!
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.truthy, true)
@@ -48,7 +48,7 @@ class DefaultFalseTests: XCTestCase {
         XCTAssertEqual(fixture2.truthy, false)
     }
 
-    func testDecodingMisalignedBoolStringValueFromJSONTraversesCorrectType() throws {
+    func testDecodingMisalignedBoolStringValueDecodesCorrectBoolValue() throws {
         let jsonData = #"{ "truthy": "true" }"#.data(using: .utf8)!
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.truthy, true)

--- a/Tests/BetterCodableTests/DefaultFalseTests.swift
+++ b/Tests/BetterCodableTests/DefaultFalseTests.swift
@@ -57,4 +57,14 @@ class DefaultFalseTests: XCTestCase {
         let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
         XCTAssertEqual(fixture2.truthy, false)
     }
+
+    func testDecodingInvalidValueDecodesToDefaultValue() throws {
+        let jsonData = #"{ "truthy": "invalidValue" }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(
+            fixture.truthy,
+            false,
+            "Should fall in to the else block and return default value"
+        )
+    }
 }

--- a/Tests/BetterCodableTests/DefaultFalseTests.swift
+++ b/Tests/BetterCodableTests/DefaultFalseTests.swift
@@ -37,4 +37,14 @@ class DefaultFalseTests: XCTestCase {
         
         XCTAssertEqual(fixture.truthy, true)
     }
+
+    func testDecodingMisalignedBoolIntValueFromJSONTraversesCorrectType() throws {
+        let jsonData = #"{ "truthy": 1 }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.truthy, true)
+
+        let jsonData2 = #"{ "truthy": 0 }"#.data(using: .utf8)!
+        let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
+        XCTAssertEqual(fixture2.truthy, false)
+    }
 }

--- a/Tests/BetterCodableTests/DefaultFalseTests.swift
+++ b/Tests/BetterCodableTests/DefaultFalseTests.swift
@@ -47,4 +47,14 @@ class DefaultFalseTests: XCTestCase {
         let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
         XCTAssertEqual(fixture2.truthy, false)
     }
+
+    func testDecodingMisalignedBoolStringValueFromJSONTraversesCorrectType() throws {
+        let jsonData = #"{ "truthy": "true" }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.truthy, true)
+
+        let jsonData2 = #"{ "truthy": "false" }"#.data(using: .utf8)!
+        let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
+        XCTAssertEqual(fixture2.truthy, false)
+    }
 }

--- a/Tests/BetterCodableTests/DefaultTrueTests.swift
+++ b/Tests/BetterCodableTests/DefaultTrueTests.swift
@@ -46,13 +46,25 @@ class DefaultTrueTests: XCTestCase {
         let jsonData2 = #"{ "truthy": 0 }"#.data(using: .utf8)!
         let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
         XCTAssertEqual(fixture2.truthy, false)
+    }
 
-        let jsonData3 = #"{ "truthy": "invalidValue" }"#.data(using: .utf8)!
-        let fixture3 = try JSONDecoder().decode(Fixture.self, from: jsonData3)
+    func testDecodingInvalidValueDecodesToDefaultValue() throws {
+        let jsonData = #"{ "truthy": "invalidValue" }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(
-            fixture3.truthy,
+            fixture.truthy,
             true,
             "Should fall in to the else block and return default value"
         )
+    }
+
+    func testDecodingMisalignedBoolStringValueFromJSONTraversesCorrectType() throws {
+        let jsonData = #"{ "truthy": "true" }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.truthy, true)
+
+        let jsonData2 = #"{ "truthy": "false" }"#.data(using: .utf8)!
+        let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
+        XCTAssertEqual(fixture2.truthy, false)
     }
 }

--- a/Tests/BetterCodableTests/DefaultTrueTests.swift
+++ b/Tests/BetterCodableTests/DefaultTrueTests.swift
@@ -38,7 +38,7 @@ class DefaultTrueTests: XCTestCase {
         XCTAssertEqual(fixture.truthy, true)
     }
 
-    func testDecodingMisalignedBoolIntValueFromJSONTraversesCorrectType() throws {
+    func testDecodingMisalignedBoolIntValueDecodesCorrectBoolValue() throws {
         let jsonData = #"{ "truthy": 1 }"#.data(using: .utf8)!
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.truthy, true)
@@ -58,7 +58,7 @@ class DefaultTrueTests: XCTestCase {
         )
     }
 
-    func testDecodingMisalignedBoolStringValueFromJSONTraversesCorrectType() throws {
+    func testDecodingMisalignedBoolStringValueDecodesCorrectBoolValue() throws {
         let jsonData = #"{ "truthy": "true" }"#.data(using: .utf8)!
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.truthy, true)

--- a/Tests/BetterCodableTests/DefaultTrueTests.swift
+++ b/Tests/BetterCodableTests/DefaultTrueTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import BetterCodable
+
+class DefaultTrueTests: XCTestCase {
+    struct Fixture: Equatable, Codable {
+        @DefaultTrue var truthy: Bool
+    }
+
+    func testDecodingFailableArrayDefaultsToFalse() throws {
+        let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.truthy, true)
+    }
+
+    func testDecodingKeyNotPresentDefaultsToFalse() throws {
+        let jsonData = #"{}"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.truthy, true)
+    }
+
+    func testEncodingDecodedFailableArrayDefaultsToFalse() throws {
+        let jsonData = #"{ "truthy": null }"#.data(using: .utf8)!
+        var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+
+        _fixture.truthy = false
+
+        let fixtureData = try JSONEncoder().encode(_fixture)
+        let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
+        XCTAssertEqual(fixture.truthy, false)
+    }
+
+    func testEncodingDecodedFulfillableBoolRetainsValue() throws {
+        let jsonData = #"{ "truthy": true }"#.data(using: .utf8)!
+        let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        let fixtureData = try JSONEncoder().encode(_fixture)
+        let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
+
+        XCTAssertEqual(fixture.truthy, true)
+    }
+
+    func testDecodingMisalignedBoolIntValueFromJSONTraversesCorrectType() throws {
+        let jsonData = #"{ "truthy": 1 }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.truthy, true)
+
+        let jsonData2 = #"{ "truthy": 0 }"#.data(using: .utf8)!
+        let fixture2 = try JSONDecoder().decode(Fixture.self, from: jsonData2)
+        XCTAssertEqual(fixture2.truthy, false)
+
+        let jsonData3 = #"{ "truthy": "invalidValue" }"#.data(using: .utf8)!
+        let fixture3 = try JSONDecoder().decode(Fixture.self, from: jsonData3)
+        XCTAssertEqual(
+            fixture3.truthy,
+            true,
+            "Should fall in to the else block and return default value"
+        )
+    }
+}

--- a/Tests/BetterCodableTests/LosslessValueTests.swift
+++ b/Tests/BetterCodableTests/LosslessValueTests.swift
@@ -9,10 +9,6 @@ class LosslessValueTests: XCTestCase {
         @LosslessValue var double: Double
     }
 
-    struct BoolFixture: Equatable, Codable {
-        @LosslessValue var bool: Bool
-    }
-    
     func testDecodingMisalignedTypesFromJSONTraversesCorrectType() throws {
         let jsonData = #"{ "bool": "true", "string": 42, "int": "7", "double": "7.1" }"#.data(using: .utf8)!
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
@@ -46,15 +42,5 @@ class LosslessValueTests: XCTestCase {
         XCTAssertEqual(fixture.string, "42")
         XCTAssertEqual(fixture.int, 7)
         XCTAssertEqual(fixture.double, 7.1)
-    }
-
-    func testDecodingMisalignedBoolIntValueFromJSONTraversesCorrectType() throws {
-        let jsonData = #"{ "bool": 1 }"#.data(using: .utf8)!
-        let fixture = try JSONDecoder().decode(BoolFixture.self, from: jsonData)
-        XCTAssertEqual(fixture.bool, true)
-
-        let jsonData2 = #"{ "bool": 0 }"#.data(using: .utf8)!
-        let fixture2 = try JSONDecoder().decode(BoolFixture.self, from: jsonData2)
-        XCTAssertEqual(fixture2.bool, false)
     }
 }

--- a/Tests/BetterCodableTests/LosslessValueTests.swift
+++ b/Tests/BetterCodableTests/LosslessValueTests.swift
@@ -8,6 +8,10 @@ class LosslessValueTests: XCTestCase {
         @LosslessValue var int: Int
         @LosslessValue var double: Double
     }
+
+    struct BoolFixture: Equatable, Codable {
+        @LosslessValue var bool: Bool
+    }
     
     func testDecodingMisalignedTypesFromJSONTraversesCorrectType() throws {
         let jsonData = #"{ "bool": "true", "string": 42, "int": "7", "double": "7.1" }"#.data(using: .utf8)!
@@ -42,5 +46,15 @@ class LosslessValueTests: XCTestCase {
         XCTAssertEqual(fixture.string, "42")
         XCTAssertEqual(fixture.int, 7)
         XCTAssertEqual(fixture.double, 7.1)
+    }
+
+    func testDecodingMisalignedBoolIntValueFromJSONTraversesCorrectType() throws {
+        let jsonData = #"{ "bool": 1 }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(BoolFixture.self, from: jsonData)
+        XCTAssertEqual(fixture.bool, true)
+
+        let jsonData2 = #"{ "bool": 0 }"#.data(using: .utf8)!
+        let fixture2 = try JSONDecoder().decode(BoolFixture.self, from: jsonData2)
+        XCTAssertEqual(fixture2.bool, false)
     }
 }

--- a/Tests/BetterCodableTests/LosslessValueTests.swift
+++ b/Tests/BetterCodableTests/LosslessValueTests.swift
@@ -43,4 +43,15 @@ class LosslessValueTests: XCTestCase {
         XCTAssertEqual(fixture.int, 7)
         XCTAssertEqual(fixture.double, 7.1)
     }
+
+    func testDecodingBoolIntValueFromJSONDecodesCorrectly() throws {
+        let jsonData = #"{ "bool": 1, "string": "42", "int": 7, "double": 7.1 }"#.data(using: .utf8)!
+        let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        let fixtureData = try JSONEncoder().encode(_fixture)
+        let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
+        XCTAssertEqual(fixture.bool, true)
+        XCTAssertEqual(fixture.string, "42")
+        XCTAssertEqual(fixture.int, 7)
+        XCTAssertEqual(fixture.double, 7.1)
+    }
 }


### PR DESCRIPTION
Currently, the `LosslessValue` PropertyWrapper saves you the trouble of managing the inconsistencies of the server sending different types for one expected type and it does it well. However, it doesn't cover all the cases. It misses the case where a `Bool` value might be sent as an `Int` value, instead of a `String`. This PR shows the failure of `LosslessValue` when you attempt to decode a Bool as an Int by adding test cases for the scenario.

## Expected Behavior
The `LosslessValue` PropertyWrapper to successfully decode a Bool value from an Int 0/1 value.

## Current Behavior
The `LosslessValue` PropertyWrapper throws a `typeMismatchError` as Bool can not be constructed from a number string "0"/"1"

## Possible Solution
This PR is to discuss possible solutions as it can be done many ways. Two possible solutions might be:

1. First solution can be that we add explicit code in `LosslessValue` PropertyWrapper to handle the Bool being constructed from an Int value. Problem with this solution is that it seems a bit hacky to explicitly handle the bool value case decoding in a more general PropertyWrapper like the `LosslessValue`.

2. Second solution that might also be desirable is to write a `KeyedDecodingContainer` extension for when the `Decodable` type is `DefaultFalse` PropertyWrapper and handle the specific scenario in that extension. If everything fails while attempting to decode successfully, we default to the default value. Problem with this solution is that if someone were to add a `DefaultTrue` PropertyWrapper the code would have to be duplicated. 

## Steps to Reproduce
Run tests added in this PR
