### PR TITLE
Add Equatable and Hashable to DateValue

### DIFF
--- a/Sources/BetterCodable/DateValue.swift
+++ b/Sources/BetterCodable/DateValue.swift
@@ -37,3 +37,15 @@ extension DateValue: Encodable where Formatter.RawValue: Encodable {
         try value.encode(to: encoder)
     }
 }
+
+extension DateValue: Equatable {
+    public static func == (lhs: DateValue<Formatter>, rhs: DateValue<Formatter>) -> Bool {
+        return lhs.wrappedValue == rhs.wrappedValue
+    }
+}
+
+extension DateValue: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(wrappedValue)
+    }
+}


### PR DESCRIPTION
Equatable and Hashable conformance was missing from `DateValue`
This PR Adds them.