### PR TITLE
Bring Polymorphism to codable

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,65 @@ let result = try JSONDecoder().decode(Response.self, from: json)
 // This produces two valid `Date` values, `updatedAt` representing October 19, 2019 and `birthday` January 22nd, 1984.
 ```
 
+## PolymorphicValue
+
+Decodes Polymorphic value by attempting to parse the value into it's preferred type. This is useful when data may return an array of objects that may be of a different type.
+
+### Usage
+
+Start by creating an enum that has variants for the parsable type it must adhere to PolymorphicFamily and define the type information `discriminator`.
+
+```swift
+enum DrinkFamily: String, PolymorphicFamily {
+    case drink = "drink"
+    case soda = "soda"
+
+    static var discriminator: Discriminator = .type
+
+    func getType() -> Drink.Type {
+        switch self {
+        case .soda:
+            return Soda.self
+        case .drink:
+            return Drink.self
+        }
+    }
+}
+
+class Drink: Codable {
+    let description: String
+}
+
+class Soda: Drink {
+    var sugar_content: String
+
+    private enum CodingKeys: String, CodingKey {
+        case sugar_content
+    }
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.sugar_content = try container.decode(String.self, forKey: .sugar_content)
+        try super.init(from: decoder)
+    }
+
+    override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sugar_content, forKey: .sugar_content)
+        try super.encode(to: encoder)
+    }
+}
+
+struct Response: Codable {
+    @PolymorphicValue<DrinkFamily> var drink: Drink
+}
+
+let jsonData = #"{"drink": {"type": "soda", "description": "Coca-Cola", "sugar_content": "5%"}}"#.data(using: .utf8)!
+let result = try JSONDecoder().decode(Response.self, from: json)
+
+// This produces a valid `Soda` instance.
+```
+
 ## Installation
 
 ### CocoaPods

--- a/Sources/BetterCodable/PolymorphicValue.swift
+++ b/Sources/BetterCodable/PolymorphicValue.swift
@@ -1,0 +1,55 @@
+/// Discriminator key enum used to retrieve the type of the encodable/decodable value.
+public enum Discriminator: String, CodingKey {
+    case type = "type"
+}
+
+/// To decode/encode a family of types, create an enum that conforms to this protocol and contains the parseable types.
+public protocol PolymorphicFamily: Codable {
+    associatedtype BaseType : Codable
+
+    /// The discriminator key.
+    static var discriminator: Discriminator { get }
+
+    /// Returns the class type of the object coresponding to the value.
+    func getType() -> BaseType.Type
+}
+
+extension PolymorphicFamily {
+    static var discriminator: Discriminator {
+        return .type
+    }
+}
+
+/// Decodes Polymorphic value by attempting to parse the value into it's preferred type.
+///
+/// This is useful when data may return an array of objects that may be of a different type.
+@propertyWrapper
+public struct PolymorphicValue<Family: PolymorphicFamily> {
+    private let family: Family
+    public var wrappedValue: Family.BaseType
+
+    public init(family: Family, wrappedValue: Family.BaseType) {
+        self.family = family
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension PolymorphicValue: Decodable {
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Discriminator.self)
+        // Decode the family with the discriminator.
+        self.family = try container.decode(Family.self, forKey: Family.discriminator)
+        // Decode the object by initialising the corresponding type.
+        self.wrappedValue = try family.getType().init(from: decoder)
+    }
+}
+
+extension PolymorphicValue: Encodable {
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Discriminator.self)
+        try container.encode(self.family, forKey: .type)
+        try wrappedValue.encode(to: encoder)
+    }
+}

--- a/Tests/BetterCodableTests/PolymorphicValueTests.swift
+++ b/Tests/BetterCodableTests/PolymorphicValueTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+import BetterCodable
+
+class Drink: Codable {
+    let description: String
+}
+
+class Soda: Drink {
+    var sugar_content: String
+
+    private enum CodingKeys: String, CodingKey {
+        case sugar_content
+    }
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.sugar_content = try container.decode(String.self, forKey: .sugar_content)
+        try super.init(from: decoder)
+    }
+
+    override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(sugar_content, forKey: .sugar_content)
+        try super.encode(to: encoder)
+    }
+}
+
+enum DrinkFamily: String, PolymorphicFamily {
+    case drink = "drink"
+    case soda = "soda"
+
+    static var discriminator: Discriminator = .type
+
+    func getType() -> Drink.Type {
+        switch self {
+        case .soda:
+            return Soda.self
+        case .drink:
+            return Drink.self
+        }
+    }
+}
+
+class PolymorphicValueTests: XCTestCase {
+
+    struct Fixture: Codable {
+        @PolymorphicValue<DrinkFamily> var drink: Drink
+    }
+    let jsonData = """
+    {
+        "drink": {
+            "type": "soda",
+            "description": "Coca-Cola",
+            "sugar_content": "5%"
+        }
+    }
+    """.data(using: .utf8)!
+
+    func testDecodingPolymorphicValue() throws {
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        guard let soda = fixture.drink as? Soda else { XCTFail(); return }
+        XCTAssertEqual(soda.sugar_content, "5%")
+    }
+
+    func testEncodingDecodedPolymorphicValue() throws {
+        let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        guard let soda = _fixture.drink as? Soda else { XCTFail(); return }
+        soda.sugar_content = "10%"
+
+        let fixtureData = try JSONEncoder().encode(_fixture)
+        let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
+        guard let soda = fixture.drink as? Soda else { XCTFail(); return }
+        XCTAssertEqual(soda.sugar_content, "10%")
+    }
+}
+


### PR DESCRIPTION
It’s not always obvious to represent our data in a strongly typed language like Swift. The consequence of this focus on strong typing is that there’s no polymorphism in the encoding/decoding. Thanks to [NSScreenCast](https://nsscreencast.com/episodes/395-decoding-heterogeneous-arrays) I was able to come out with a property wrapper to decode polymorphic values, that am trilled to share with you.

I am always open to your suggestions for further improving the way in which the code was developed.