### PR TITLE
Add OptionalLosslessValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,24 @@ let result = try JSONDecoder().decode(Response.self, from: json)
 print(result) // Response(sku: "12355", isAvailable: true)
 ```
 
+## @OptionalLosslessValue
+
+Like LosslessValue, but for optional values. `@OptionalLosslessValue` allows parsing values that may be absent or malformed, producing a nil value instead of thowing an exception. If BetterCodable can make sense of the value, `@OptionalLosslessValue` will attempt to decode a value into the type that you expect, preserving the data that would otherwise throw an exception or be lost altogether. 
+
+### Usage
+
+```Swift
+struct Response: Codable {
+    @OptionalLosslessValue var sku: String?
+    @OptionalLosslessValue var isAvailable: Bool?
+}
+
+let json = #"{ "sku": 12345 }"#.data(using: .utf8)!
+let result = try JSONDecoder().decode(Response.self, from: json)
+
+print(result) // Response(sku: "12355", isAvailable: nil)
+```
+
 ## Date Wrappers
 
 One common frustration with `Codable` is decoding entities that have mixed date formats. `JSONDecoder` comes built in with a handy `dateDecodingStrategy` property, but that uses the same date format for all dates that it will decode. And often, `JSONDecoder` lives elsewhere from the entity forcing tight coupling with the entities if you choose to use its date decoding strategy.

--- a/Sources/BetterCodable/OptionalLosslessValue.swift
+++ b/Sources/BetterCodable/OptionalLosslessValue.swift
@@ -1,0 +1,67 @@
+/// Like @LosslessValue, but produce nil on parse error/if key not present.
+public typealias OptionalLosslessValue<T> = OptionalLosslessValueCodable<LosslessDefaultStrategy<T>> where T: LosslessStringCodable
+
+/// Decodes Codable values into their respective preferred types.
+///
+/// `@OptionalLosslessValueCodable` attempts to decode Codable types into their preferred order while preserving the data in the most lossless format. If the key is not present or the value cannot be parsed, nil is produced.
+///
+/// The preferred type order is provided by a generic `LosslessDecodingStrategy` that provides an ordered list of `losslessDecodableTypes`.@propertyWrapper
+
+@propertyWrapper
+public struct OptionalLosslessValueCodable<Strategy: LosslessDecodingStrategy>: Codable {
+    private let type: LosslessStringCodable.Type
+
+    public var wrappedValue: Strategy.Value?
+
+    public init(wrappedValue: Strategy.Value) {
+        self.wrappedValue = wrappedValue
+        self.type = Strategy.Value.self
+    }
+
+    public init(wrappedValue: Strategy.Value?) {
+        self.wrappedValue = wrappedValue
+        self.type = Strategy.Value.self
+    }
+
+    public init(from decoder: Decoder) {
+        do {
+            self.wrappedValue = try Strategy.Value.init(from: decoder)
+            self.type = Strategy.Value.self
+        } catch {
+            guard
+                let rawValue = Strategy.losslessDecodableTypes.lazy.compactMap({ $0(decoder) }).first,
+                let value = Strategy.Value.init("\(rawValue)")
+            else {
+                self.wrappedValue = nil
+                self.type = Strategy.Value.self
+                return
+            }
+
+            self.wrappedValue = value
+            self.type = Swift.type(of: rawValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        if let wrappedValue = wrappedValue {
+            let string = String(describing: wrappedValue)
+
+            guard let original = type.init(string) else {
+                let description = "Unable to encode '\(String(describing: wrappedValue))' back to source type '\(type)'"
+                throw EncodingError.invalidValue(string, .init(codingPath: [], debugDescription: description))
+            }
+
+            try original.encode(to: encoder)
+        } else {
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+        }
+    }
+}
+
+/// Handles decoding a key that is not present. Instead of throwing an error, a nil value is produced.
+extension KeyedDecodingContainer {
+    public func decode<T: Decodable>(_ type: OptionalLosslessValueCodable<LosslessDefaultStrategy<T>>.Type, forKey key: Key) throws -> OptionalLosslessValueCodable<LosslessDefaultStrategy<T>> {
+        (try? decodeIfPresent(type, forKey: key)) ?? OptionalLosslessValueCodable<LosslessDefaultStrategy<T>>(wrappedValue: nil)
+    }
+}

--- a/Tests/BetterCodableTests/OptionalLosslessValueTests.swift
+++ b/Tests/BetterCodableTests/OptionalLosslessValueTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import BetterCodable
+
+
+class OptionalLosslessValueTests: XCTestCase {
+    struct Fixture: Codable {
+        @OptionalLosslessValue var bool: Bool?
+        @OptionalLosslessValue var string: String?
+        @OptionalLosslessValue var int: Int?
+        @OptionalLosslessValue var double: Double?
+        @OptionalLosslessValue var nilValue: Int?
+        @OptionalLosslessValue var missingKey: Double?
+    }
+
+    func testDecodingMisalignedTypesFromJSONTraversesCorrectType() throws {
+        let jsonData = #"{ "bool": "true", "string": 42, "int": "1", "double": "7.1", "nilValue": null }"#.data(using: .utf8)!
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.bool, true)
+        XCTAssertEqual(fixture.string, "42")
+        XCTAssertEqual(fixture.int, 1)
+        XCTAssertEqual(fixture.double, 7.1)
+        XCTAssertEqual(fixture.nilValue, nil)
+        XCTAssertEqual(fixture.missingKey, nil)
+    }
+
+    func testDecodingEncodedMisalignedTypesFromJSONDecodesCorrectTypes() throws {
+        let jsonData = #"{ "bool": "true", "string": 42, "int": "7", "double": "7.1", "nilValue": null }"#.data(using: .utf8)!
+        var _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+
+        _fixture.bool = false
+        _fixture.double = 3.14
+
+        let fixtureData = try JSONEncoder().encode(_fixture)
+        let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
+        XCTAssertEqual(fixture.bool, false)
+        XCTAssertEqual(fixture.string, "42")
+        XCTAssertEqual(fixture.int, 7)
+        XCTAssertEqual(fixture.double, 3.14)
+        XCTAssertEqual(fixture.nilValue, nil)
+        XCTAssertEqual(fixture.missingKey, nil)
+    }
+
+    func testEncodingAndDecodedExpectedTypes() throws {
+        let jsonData = #"{ "bool": true, "string": "42", "int": 7, "double": 7.1, "nilValue": null }"#.data(using: .utf8)!
+        let _fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        let fixtureData = try JSONEncoder().encode(_fixture)
+        let fixture = try JSONDecoder().decode(Fixture.self, from: fixtureData)
+        XCTAssertEqual(fixture.bool, true)
+        XCTAssertEqual(fixture.string, "42")
+        XCTAssertEqual(fixture.int, 7)
+        XCTAssertEqual(fixture.double, 7.1)
+        XCTAssertEqual(fixture.nilValue, nil)
+        XCTAssertEqual(fixture.missingKey, nil)
+    }
+}


### PR DESCRIPTION
We are building a robust parsing layer where any API data is parsed into Codable structs that are then further transformed to app-domain model objects. BetterCodable turned out to help a lot in the parsing layer, but a few things rendered missing, which I would like to add in maybe two or three pull requests, open for any discussion.

I would like to start with OptionalLosslessValue:

The motivation is to have the behavior of LosslessValue, where integers, strings, booleans, … are converted losslessly but to allow the value in question to be absent, null or even unparsable. In our use case, it is desirable for these cases to produce a nil value instead of throwing a parsing error because then higher layer code can decide whether the absence of the value is a real problem or not.
