### PR TITLE
`LossyDictionary`: added failing test and fix for key conversion issue

### DIFF
--- a/Tests/BetterCodableTests/LossyDictionaryTests.swift
+++ b/Tests/BetterCodableTests/LossyDictionaryTests.swift
@@ -75,4 +75,27 @@ class LossyDictionaryTests: XCTestCase {
         XCTAssertEqual(fixture.stringToInt, ["one": 1, "two": 2, "three": 3])
         XCTAssertEqual(fixture.intToString, [1: "one", 2: "two", 3: "three"])
     }
+
+    func testEncodingLosslessDictionaryRetainsKeys() throws {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+
+        let fixture = Fixture(
+            stringToInt: [
+                "snake_case.with.dots_99.and_numbers": 1,
+                "dots.and_2.00.1_numbers": 2,
+                "key.1": 3,
+                "normal key": 4,
+                "another_key": 5
+            ],
+            intToString: [:]
+        )
+
+        let reencodedFixture = try decoder.decode(Fixture.self, from: encoder.encode(fixture))
+
+        XCTAssertEqual(reencodedFixture, fixture)
+    }
 }


### PR DESCRIPTION
The property wrapper `LossyDictionary` incorrectly decodes keys with `KeyDecodingStrategy.convertFromSnakeCase`.
The test simply encodes and decodes a sample data, to illustrate that the conversion isn't idempotent.

Keys were being converted to camel case, which is inconsistent from the default behavior that `container.decode([String: Value].self, forKey: key)` would have.
The reason for this is some implementation detail in `Foundation` that ignores the `keyDecodingStrategy` when decoding "raw" dictionaries versus property names.

To deal with this, this decodes the strings first as "raw", and then matches them to the corresponding converted key.