### PR TITLE
Conform wrapped properties to `Sendable`

### DIFF
--- a/Sources/BetterCodable/DateValue.swift
+++ b/Sources/BetterCodable/DateValue.swift
@@ -49,3 +49,7 @@ extension DateValue: Hashable {
         hasher.combine(wrappedValue)
     }
 }
+
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+extension DateValue: Sendable where Formatter.RawValue: Sendable { }
+#endif

--- a/Sources/BetterCodable/DefaultCodable.swift
+++ b/Sources/BetterCodable/DefaultCodable.swift
@@ -40,6 +40,10 @@ extension DefaultCodable: Encodable where Default.DefaultValue: Encodable {
 extension DefaultCodable: Equatable where Default.DefaultValue: Equatable { }
 extension DefaultCodable: Hashable where Default.DefaultValue: Hashable { }
 
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+extension DefaultCodable: Sendable where Default.DefaultValue: Sendable { }
+#endif
+
 // MARK: - KeyedDecodingContainer
 public protocol BoolCodableStrategy: DefaultCodableStrategy where DefaultValue == Bool {}
 

--- a/Sources/BetterCodable/LosslessArray.swift
+++ b/Sources/BetterCodable/LosslessArray.swift
@@ -42,3 +42,7 @@ extension LosslessArray: Encodable where T: Encodable {
 
 extension LosslessArray: Equatable where T: Equatable {}
 extension LosslessArray: Hashable where T: Hashable {}
+
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+extension LosslessArray: Sendable where T: Sendable { }
+#endif

--- a/Sources/BetterCodable/LosslessValue.swift
+++ b/Sources/BetterCodable/LosslessValue.swift
@@ -68,6 +68,10 @@ extension LosslessValueCodable: Hashable where Strategy.Value: Hashable {
     }
 }
 
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+extension LosslessValueCodable: Sendable where Strategy.Value: Sendable { }
+#endif
+
 public struct LosslessDefaultStrategy<Value: LosslessStringCodable>: LosslessDecodingStrategy {
     public static var losslessDecodableTypes: [(Decoder) -> LosslessStringCodable?] {
         @inline(__always)

--- a/Sources/BetterCodable/LossyArray.swift
+++ b/Sources/BetterCodable/LossyArray.swift
@@ -40,3 +40,7 @@ extension LossyArray: Encodable where T: Encodable {
 
 extension LossyArray: Equatable where T: Equatable { }
 extension LossyArray: Hashable where T: Hashable { }
+
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+extension LossyArray: Sendable where T: Sendable { }
+#endif

--- a/Sources/BetterCodable/LossyDictionary.swift
+++ b/Sources/BetterCodable/LossyDictionary.swift
@@ -106,3 +106,7 @@ extension LossyDictionary: Encodable where Key: Encodable, Value: Encodable {
 }
 
 extension LossyDictionary: Equatable where Key: Equatable, Value: Equatable { }
+
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+extension LossyDictionary: Sendable where Key: Sendable, Value: Sendable { }
+#endif


### PR DESCRIPTION
Hello!
This PR makes wrapped properties conditionally conform to `Sendable` when their dependencies are `Sendable`.
This should help data structs using these wrappers to pass through async contexts when possible.