### PR TITLE
Resolve all warnings for Xcode 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "BetterCodable",
     platforms: [
         .iOS(.v10),
-        .macOS(.v10_12),
+        .macOS(.v10_13),
         .tvOS(.v10),
         .watchOS(.v3)
     ],

--- a/Sources/BetterCodable/DefaultCodable.swift
+++ b/Sources/BetterCodable/DefaultCodable.swift
@@ -24,7 +24,7 @@ public struct DefaultCodable<Default: DefaultCodableStrategy> {
     }
 }
 
-extension DefaultCodable: Decodable where Default.DefaultValue: Decodable {
+extension DefaultCodable: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         self.wrappedValue = (try? container.decode(Default.DefaultValue.self)) ?? Default.defaultValue

--- a/Sources/BetterCodable/LossyDictionary.swift
+++ b/Sources/BetterCodable/LossyDictionary.swift
@@ -105,4 +105,4 @@ extension LossyDictionary: Encodable where Key: Encodable, Value: Encodable {
     }
 }
 
-extension LossyDictionary: Equatable where Key: Equatable, Value: Equatable { }
+extension LossyDictionary: Equatable where Value: Equatable { }


### PR DESCRIPTION
Minor warnings cleanup. Xcode 14 drops support for macOS 10.12. Removes some redundant conformances.