### PR TITLE
Add failedDecodes to LossyArray

### DIFF
--- a/Tests/BetterCodableTests/LossyArrayTests.swift
+++ b/Tests/BetterCodableTests/LossyArrayTests.swift
@@ -17,6 +17,8 @@ class LossyArrayTests: XCTestCase {
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.values, [1, 3, 4])
         XCTAssertEqual(fixture.nonPrimitiveValues, [])
+        XCTAssertEqual(fixture.$values.failedDecodes.count, 1)
+        XCTAssertEqual(fixture.$nonPrimitiveValues.failedDecodes.count, 1)
     }
 
 	func testDecodingLossyArrayIgnoresLossyElements() throws {
@@ -24,6 +26,8 @@ class LossyArrayTests: XCTestCase {
         let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
         XCTAssertEqual(fixture.values, [1, 4])
         XCTAssertEqual(fixture.nonPrimitiveValues, [])
+        XCTAssertEqual(fixture.$values.failedDecodes.count, 3)
+        XCTAssertEqual(fixture.$nonPrimitiveValues.failedDecodes.count, 1)
 	}
     
     func testEncodingDecodedLossyArrayIgnoresFailableElements() throws {


### PR DESCRIPTION
This is the beginning of an approach I'm considering regarding #41 to track failures. Rather than injecting logging into the system, it tracks failures such that you can check at the end if anything went wrong. I'm exploring whether I can use Mirror to scan a final data structure and collect all failures including in children. But I first wanted to pitch the basic approach and get any input.

I at least want to add this to the other Lossy types, and am considering how to best handle the Default types. Currently "default" is used both to mean "value when there is no value to avoid Optionals" and also "value when the data is corrupt to avoid throwing." IMO these are very different use cases, and I'm thinking through how to best split them up and make their differences explicit.