### PR TITLE
Handle Data encodings

### DIFF
--- a/Sources/BetterCodable/Base64Strategy.swift
+++ b/Sources/BetterCodable/Base64Strategy.swift
@@ -3,16 +3,16 @@ import Foundation
 /// Decodes `String` values as a Base64-encoded `Data`.
 ///
 /// Decodes strictly valid Base64. This does not handle b64url encoding, invalid padding, or unknown characters.
-public struct Base64Strategy: DataValueCodableStrategy {
-    public static func decode(_ value: String) throws -> Data {
+public struct Base64Strategy<DataType: MutableDataProtocol>: DataValueCodableStrategy {
+    public static func decode(_ value: String) throws -> DataType {
         if let data = Data(base64Encoded: value) {
-            return data
+            return DataType(data)
         } else {
             throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid Base64 Format!"))
         }
     }
 
-    public static func encode(_ data: Data) -> String {
-        data.base64EncodedString()
+    public static func encode(_ data: DataType) -> String {
+        Data(data).base64EncodedString()
     }
 }

--- a/Sources/BetterCodable/Base64Strategy.swift
+++ b/Sources/BetterCodable/Base64Strategy.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Decodes `String` values as a Base64-encoded `Data`.
+///
+/// Decodes strictly valid Base64. This does not handle b64url encoding, invalid padding, or unknown characters.
+public struct Base64Strategy: DataValueCodableStrategy {
+    public static func decode(_ value: String) throws -> Data {
+        if let data = Data(base64Encoded: value) {
+            return data
+        } else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid Base64 Format!"))
+        }
+    }
+
+    public static func encode(_ data: Data) -> String {
+        data.base64EncodedString()
+    }
+}

--- a/Sources/BetterCodable/DataValue.swift
+++ b/Sources/BetterCodable/DataValue.swift
@@ -5,10 +5,10 @@ import Foundation
 /// `DataValueCodableStrategy` provides a generic strategy type that the `DataValue` property wrapper can use to inject
 ///  custom strategies for encoding and decoding data values.
 ///
-///  TODO: Switch to DataProtocol; consider supporting
 public protocol DataValueCodableStrategy {
-    static func decode(_ value: String) throws -> Data
-    static func encode(_ data: Data) -> String
+    associatedtype DataType: MutableDataProtocol
+    static func decode(_ value: String) throws -> DataType
+    static func encode(_ data: DataType) -> String
 }
 
 /// Decodes and encodes data using a strategy type.
@@ -16,9 +16,9 @@ public protocol DataValueCodableStrategy {
 /// `@DataValue` decodes data using a `DataValueCodableStrategy` which provides custom decoding and encoding functionality.
 @propertyWrapper
 public struct DataValue<Coder: DataValueCodableStrategy> {
-    public var wrappedValue: Data
+    public var wrappedValue: Coder.DataType
 
-    public init(wrappedValue: Data) {
+    public init(wrappedValue: Coder.DataType) {
         self.wrappedValue = wrappedValue
     }
 }
@@ -35,5 +35,5 @@ extension DataValue: Encodable {
     }
 }
 
-extension DataValue: Equatable {}
-extension DataValue: Hashable {}
+extension DataValue: Equatable where Coder.DataType: Equatable {}
+extension DataValue: Hashable where Coder.DataType: Hashable {}

--- a/Sources/BetterCodable/DataValue.swift
+++ b/Sources/BetterCodable/DataValue.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// A protocol for providing a custom strategy for encoding and decoding data as strings.
+///
+/// `DataValueCodableStrategy` provides a generic strategy type that the `DataValue` property wrapper can use to inject
+///  custom strategies for encoding and decoding data values.
+///
+///  TODO: Switch to DataProtocol; consider supporting
+public protocol DataValueCodableStrategy {
+    static func decode(_ value: String) throws -> Data
+    static func encode(_ data: Data) -> String
+}
+
+/// Decodes and encodes data using a strategy type.
+///
+/// `@DataValue` decodes data using a `DataValueCodableStrategy` which provides custom decoding and encoding functionality.
+@propertyWrapper
+public struct DataValue<Coder: DataValueCodableStrategy> {
+    public var wrappedValue: Data
+
+    public init(wrappedValue: Data) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension DataValue: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.wrappedValue = try Coder.decode(String(from: decoder))
+    }
+}
+
+extension DataValue: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        try Coder.encode(wrappedValue).encode(to: encoder)
+    }
+}
+
+extension DataValue: Equatable {}
+extension DataValue: Hashable {}

--- a/Tests/BetterCodableTests/DataValueTests.swift
+++ b/Tests/BetterCodableTests/DataValueTests.swift
@@ -23,4 +23,18 @@ class DataValueTests: XCTestCase {
 
         XCTAssertThrowsError(try JSONDecoder().decode(Fixture.self, from: jsonData))
     }
+
+    func testDecodingAndEncodingBase64StringToArray() throws {
+        struct Fixture: Codable {
+            @DataValue<Base64Strategy> var data: [UInt8]
+        }
+        let jsonData = #"{"data":"QmV0dGVyQ29kYWJsZQ=="}"#.data(using: .utf8)!
+
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.data, Array("BetterCodable".utf8))
+
+        let outputJSON = try JSONEncoder().encode(fixture)
+        XCTAssertEqual(outputJSON, jsonData)
+    }
+
 }

--- a/Tests/BetterCodableTests/DataValueTests.swift
+++ b/Tests/BetterCodableTests/DataValueTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import BetterCodable
+
+class DataValueTests: XCTestCase {
+    func testDecodingAndEncodingBase64String() throws {
+        struct Fixture: Codable {
+            @DataValue<Base64Strategy> var data: Data
+        }
+        let jsonData = #"{"data":"QmV0dGVyQ29kYWJsZQ=="}"#.data(using: .utf8)!
+
+        let fixture = try JSONDecoder().decode(Fixture.self, from: jsonData)
+        XCTAssertEqual(fixture.data, Data("BetterCodable".utf8))
+
+        let outputJSON = try JSONEncoder().encode(fixture)
+        XCTAssertEqual(outputJSON, jsonData)
+    }
+
+    func testDecodingMalformedBase64Fails() throws {
+        struct Fixture: Codable {
+            @DataValue<Base64Strategy> var data: Data
+        }
+        let jsonData = #"{"data":"invalidBase64!"}"#.data(using: .utf8)!
+
+        XCTAssertThrowsError(try JSONDecoder().decode(Fixture.self, from: jsonData))
+    }
+}


### PR DESCRIPTION
This adds a simple Base64 decoding  strategy for anything conforming to MutableDataProtocol (particularly Data and [UInt8]).

It follows the pattern of #53, which I believe is more correct than the current code.