### PR TITLE
Chnage logic of Treat logical strings as truthy values

### DIFF
--- a/Sources/BetterCodable/LosslessValue.swift
+++ b/Sources/BetterCodable/LosslessValue.swift
@@ -103,9 +103,13 @@ public struct LosslessBooleanStrategy<Value: LosslessStringCodable>: LosslessDec
         func decodeTruthyString() -> (Decoder) -> LosslessStringCodable? {
             return {
                 (try? String.init(from: $0)).flatMap { value in
-                    switch value {
-                    case "true", "yes", "1", "y", "t": return true
-                    default: return false
+                    
+                    if ["true", "yes", "1", "y", "t"].contains(value.lowercased()) {
+                        return true
+                    }
+                    else {
+                        let tmp = NSNumber(value: ((Int(value) ?? 0) > 0))
+                        return Bool(truncating:tmp)
                     }
                 }
             }
@@ -113,23 +117,13 @@ public struct LosslessBooleanStrategy<Value: LosslessStringCodable>: LosslessDec
 
         @inline(__always)
         func decodeBoolFromNSNumber() -> (Decoder) -> LosslessStringCodable? {
-            return { (try? Int.init(from: $0)).flatMap { Bool(exactly: NSNumber(value: $0)) } }
+            return { (try? Int.init(from: $0)).flatMap { Bool(exactly: NSNumber(value: ($0 > 0)) ) } }
         }
-
+        
         return [
             decodeTruthyString(),
             decodeBoolFromNSNumber(),
-            decode(Bool.self),
-            decode(Int.self),
-            decode(Int8.self),
-            decode(Int16.self),
-            decode(Int64.self),
-            decode(UInt.self),
-            decode(UInt8.self),
-            decode(UInt16.self),
-            decode(UInt64.self),
-            decode(Double.self),
-            decode(Float.self),
+   
         ]
     }
 }

--- a/Tests/BetterCodableTests/LosslessValueTests.swift
+++ b/Tests/BetterCodableTests/LosslessValueTests.swift
@@ -82,9 +82,12 @@ class LosslessValueTests: XCTestCase {
             @LosslessBoolValue var c: Bool
             @LosslessBoolValue var d: Bool
             @LosslessBoolValue var e: Bool
+            @LosslessBoolValue var f: Bool
+            @LosslessBoolValue var g: Bool
         }
 
-        let json = #"{ "a": "true", "b": "yes", "c": "1", "d": "y", "e": "t" }"#.data(using: .utf8)!
+        let json = #"{ "a": "TRUE", "b": "yes", "c": "1", "d": "y", "e": "t","f":"11", "g":11 }"#.data(using: .utf8)!
+        
         let result = try JSONDecoder().decode(Response.self, from: json)
 
         XCTAssertEqual(result.a, true)
@@ -92,8 +95,10 @@ class LosslessValueTests: XCTestCase {
         XCTAssertEqual(result.c, true)
         XCTAssertEqual(result.d, true)
         XCTAssertEqual(result.e, true)
+        XCTAssertEqual(result.f, true)
+        XCTAssertEqual(result.g, true)
         
-        let json2 = #"{ "a": "false", "b": "no", "c": "0", "d": "n", "e": "f" }"#.data(using: .utf8)!
+        let json2 = #"{ "a": "FALSE", "b": "no", "c": "0", "d": "n", "e": "f","f":"-11", "g":-11  }"#.data(using: .utf8)!
         let result2 = try JSONDecoder().decode(Response.self, from: json2)
 
         XCTAssertEqual(result2.a, false)
@@ -101,5 +106,7 @@ class LosslessValueTests: XCTestCase {
         XCTAssertEqual(result2.c, false)
         XCTAssertEqual(result2.d, false)
         XCTAssertEqual(result2.e, false)
+        XCTAssertEqual(result2.f, false)
+        XCTAssertEqual(result2.g, false)
     }
 }


### PR DESCRIPTION
* use "lowercased()" would hadnle like "Ture", "YES", etc... 
* change "decodeBoolFromNSNumber()" can handle like a:11 -> true, a:-11 -> false 
* change "decodeTruthyString()" can handle like a:"11" -> true, a:"-11" -> false