### PR TITLE
[Fix] Generic Parameter Shadow Warning with Swift 5.9

### DIFF
--- a/Sources/BetterCodable/LossyDictionary.swift
+++ b/Sources/BetterCodable/LossyDictionary.swift
@@ -29,7 +29,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
     }
 
     private struct AnyDecodableValue: Decodable {}
-    private struct LossyDecodableValue<Value: Decodable>: Decodable {
+    private struct LossyDecodableValue: Decodable {
         let value: Value
 
         public init(from decoder: Decoder) throws {
@@ -46,7 +46,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
 
             for (key, stringKey) in keys {
                 do {
-                    let value = try container.decode(LossyDecodableValue<Value>.self, forKey: key).value
+                    let value = try container.decode(LossyDecodableValue.self, forKey: key).value
                     elements[stringKey as! Key] = value
                 } catch {
                     _ = try? container.decode(AnyDecodableValue.self, forKey: key)
@@ -67,7 +67,7 @@ extension LossyDictionary: Decodable where Key: Decodable, Value: Decodable {
                 }
 
                 do {
-                    let value = try container.decode(LossyDecodableValue<Value>.self, forKey: key).value
+                    let value = try container.decode(LossyDecodableValue.self, forKey: key).value
                     elements[key.intValue! as! Key] = value
                 } catch {
                     _ = try? container.decode(AnyDecodableValue.self, forKey: key)

--- a/Tests/BetterCodableTests/DefaultCodableTests.swift
+++ b/Tests/BetterCodableTests/DefaultCodableTests.swift
@@ -199,6 +199,6 @@ class DefaultCodableTests_EnumWithAssociatedValue: XCTestCase {
 		
 		let data = try JSONEncoder().encode(fixture)
 		let str = String(data: data, encoding: .utf8)
-		XCTAssertEqual(str, #"{"value":{"int":4,"fish":"ziz"}}"#)
+		XCTAssertEqual(str, #"{"value":{"fish":"ziz","int":4}}"#)
 	}
 }


### PR DESCRIPTION
With the release of Xcode 15 we now have Swift 5.9. With that there comes a new warning about shadowing generic parameters, see https://github.com/apple/swift/issues/62767. There is one place in this repository affected:
<img width="1645" alt="Screenshot 2023-09-14 at 12 48 56" src="https://github.com/marksands/BetterCodable/assets/42500484/dbe9954e-caaf-4f9e-b77c-2f12d13d8dea">

## Implementation Details

It turns out that we don't need the generic parameter on this type at all, it's a private struct nested inside the type that already has the parameter defined, so there is no need to parse it through. Another approach would be to just rename the shadowed, inner parameter to something like `V` but IMO we should just remove it. Let me know if there are any concerns...

I have also fixed one failing test, the compare json had the opposite order compared to how it is defined in the CodingKeys.

## Conclusion

This warning will be an error in Swift 6 so we should get that fix in, the sooner the better!